### PR TITLE
feat: 공통 webClient 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,15 @@ subprojects {
 
 	dependencies {
 		implementation 'org.springframework.boot:spring-boot-starter'
+		implementation 'org.projectlombok:lombok:1.18.22'
 		testImplementation 'org.springframework.boot:spring-boot-starter-test'
+		annotationProcessor 'org.projectlombok:lombok:1.18.22'
+
+		configurations {
+			compileOnly {
+				extendsFrom annotationProcessor
+			}
+		}
 	}
 
 	test {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,3 @@
 rootProject.name = 'srvr'
 include 'srvr-main'
+include 'srvr-common'

--- a/srvr-common/build.gradle
+++ b/srvr-common/build.gradle
@@ -1,0 +1,5 @@
+dependencies {
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
+    implementation 'org.springframework:spring-webflux'
+    implementation 'org.springframework.boot:spring-boot-starter-reactor-netty'
+}

--- a/srvr-common/src/main/java/kr/kro/srvrstudy/srvr_common/api/Api.java
+++ b/srvr-common/src/main/java/kr/kro/srvrstudy/srvr_common/api/Api.java
@@ -1,0 +1,15 @@
+package kr.kro.srvrstudy.srvr_common.api;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+
+import java.util.function.Consumer;
+
+public interface Api {
+
+    HttpMethod getMethod();
+    String getUrI();
+    Consumer<HttpHeaders> getHeaders();
+    String getBody();
+
+}

--- a/srvr-common/src/main/java/kr/kro/srvrstudy/srvr_common/api/ApiClient.java
+++ b/srvr-common/src/main/java/kr/kro/srvrstudy/srvr_common/api/ApiClient.java
@@ -1,0 +1,27 @@
+package kr.kro.srvrstudy.srvr_common.api;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@RequiredArgsConstructor
+public class ApiClient {
+
+    private final WebClient webClient;
+
+    public <R> Mono<R> requestMono(Api api, Class<R> rClass) {
+        return sendRequest(api).bodyToMono(rClass);
+    }
+
+    public <R> Flux<R> requestFlux(Api api, Class<R> rClass) {
+        return sendRequest(api).bodyToFlux(rClass);
+    }
+
+    private WebClient.ResponseSpec sendRequest(Api api) {
+        return webClient.method(api.getMethod()).uri(api.getUrI())
+                .headers(api.getHeaders())
+                .body(api.getBody(), api.getBody().getClass())
+                .retrieve();
+    }
+}

--- a/srvr-common/src/main/java/kr/kro/srvrstudy/srvr_common/api/response/ApiResponse.java
+++ b/srvr-common/src/main/java/kr/kro/srvrstudy/srvr_common/api/response/ApiResponse.java
@@ -1,0 +1,41 @@
+package kr.kro.srvrstudy.srvr_common.api.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Collection;
+import java.util.Optional;
+
+@Setter
+@Getter
+public abstract class ApiResponse<T> {
+
+    private BodyHeader header;
+    private BodyContent<T> content;
+
+    @Setter
+    @Getter
+    private static class BodyHeader {
+
+        private boolean isSuccessful;
+        private String message;
+        private long code;
+
+    }
+
+    @Setter
+    @Getter
+    public static class BodyContent<T> {
+
+        @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+        private Optional<Long> totalCount;
+
+        @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+        private Optional<T> content;
+
+        @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+        private Optional<Collection<T>> contents;
+
+    }
+}

--- a/srvr-common/src/main/java/kr/kro/srvrstudy/srvr_common/config/ApiClientConfig.java
+++ b/srvr-common/src/main/java/kr/kro/srvrstudy/srvr_common/config/ApiClientConfig.java
@@ -1,0 +1,33 @@
+package kr.kro.srvrstudy.srvr_common.config;
+
+import io.netty.channel.ChannelOption;
+import kr.kro.srvrstudy.srvr_common.api.ApiClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+import java.time.Duration;
+
+
+@Configuration
+public class ApiClientConfig {
+
+    @Bean
+    public WebClient webClient() {
+        HttpClient httpClient = HttpClient.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 10000)
+                .responseTimeout(Duration.ofSeconds(2));
+
+        return WebClient.builder()
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(2 * 1024 * 1024))
+                .build();
+    }
+
+    @Bean
+    public ApiClient apiClient(WebClient webClient) {
+        return new ApiClient(webClient);
+    }
+}


### PR DESCRIPTION
### 내용 

- 각 기능 서버간 통신을 위한 Api 인터페이스 생성
기능 서버 api를 정리하 쉽도록 Api 인터페이스를 작성했고 각 관련있는 기능서버 간의 enum 타입 API를 정리해서 쓸 수 있도록 설계하고 작성했습니다.
```
// auth server api
enum AuthServerApi

AUTHENTICATE_USER(method, url, header, body),
...;

private method;
private url;
....
```

- 공통 response format 설정
```
responseBody 
{
    header: {
        long code // 에러용
        String message // 에러용
        isSuccessful: true/false,
    },
    content: { GenericType },
    contents: [{ GenericType }],
    totalCount: 0 // contents일 경우에만 노출되는 필드 contents의 개수
}
```

- webClient 설정 추가
기본 설정만 진행했고 추후에 설정을 추가하면 될 듯 합니다.
(아직 설정에 대해서 잘 알지 못 함.)

### 주의
- 각 기능서버에 해당 모듈을 dependency에 추가해서 사용하는 것으로 생각했는데 재대로 빈등록이 될지 모르겠습니다.. 해보고 개선해야합니다.