### PR TITLE
feat: srvr_common 공통 모듈 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,15 @@ subprojects {
 
 	dependencies {
 		implementation 'org.springframework.boot:spring-boot-starter'
+		implementation 'org.projectlombok:lombok:1.18.22'
 		testImplementation 'org.springframework.boot:spring-boot-starter-test'
+		annotationProcessor 'org.projectlombok:lombok:1.18.22'
+
+		configurations {
+			compileOnly {
+				extendsFrom annotationProcessor
+			}
+		}
 	}
 
 	test {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,3 @@
 rootProject.name = 'srvr'
 include 'srvr-main'
+include 'srvr-common'

--- a/srvr-common/build.gradle
+++ b/srvr-common/build.gradle
@@ -1,0 +1,6 @@
+dependencies {
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
+    implementation 'org.springframework:spring-webflux'
+    implementation 'org.springframework.boot:spring-boot-starter-reactor-netty'
+    implementation 'io.netty:netty-all'
+}

--- a/srvr-common/src/main/java/kr/kro/srvrstudy/srvr_common/api/response/ApiResponse.java
+++ b/srvr-common/src/main/java/kr/kro/srvrstudy/srvr_common/api/response/ApiResponse.java
@@ -1,0 +1,52 @@
+package kr.kro.srvrstudy.srvr_common.api.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Collection;
+import java.util.Optional;
+
+@Getter
+public abstract class ApiResponse<T> {
+
+    private final BodyHeader header;
+    private final BodyContent<T> result;
+
+    ApiResponse(BodyHeader header, BodyContent<T> result) {
+        this.header = header;
+        this.result = result;
+    }
+
+    @RequiredArgsConstructor
+    @Getter
+    static class BodyHeader {
+
+        private final boolean isSuccessful;
+        private final String message;
+        private final long code;
+
+    }
+
+    @Getter
+    public static class BodyContent<T> {
+
+        @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+        private Optional<Integer> totalCount;
+
+        @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+        private Optional<T> content;
+
+        @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+        private Optional<Collection<T>> contents;
+
+        public BodyContent(T content) {
+            this.content = Optional.of(content);
+        }
+
+        public BodyContent(Collection<T> contents) {
+            this.totalCount = Optional.of(contents.size());
+            this.contents = Optional.of(contents);
+        }
+    }
+}

--- a/srvr-common/src/main/java/kr/kro/srvrstudy/srvr_common/api/response/SuccessResponse.java
+++ b/srvr-common/src/main/java/kr/kro/srvrstudy/srvr_common/api/response/SuccessResponse.java
@@ -1,0 +1,18 @@
+package kr.kro.srvrstudy.srvr_common.api.response;
+
+import java.util.Collection;
+
+public class SuccessResponse<T> extends ApiResponse<T> {
+
+    public SuccessResponse() {
+        super(new BodyHeader(true, "", 0), null);
+    }
+
+    public SuccessResponse(T body) {
+        super(new BodyHeader(true, "", 0), new BodyContent<>(body));
+    }
+
+    public SuccessResponse(Collection<T> body) {
+        super(new BodyHeader(true, "", 0), new BodyContent<>(body));
+    }
+}

--- a/srvr-common/src/main/java/kr/kro/srvrstudy/srvr_common/config/ApiClientConfig.java
+++ b/srvr-common/src/main/java/kr/kro/srvrstudy/srvr_common/config/ApiClientConfig.java
@@ -1,0 +1,26 @@
+package kr.kro.srvrstudy.srvr_common.config;
+
+import io.netty.channel.ChannelOption;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+import java.time.Duration;
+
+
+@Configuration
+public class ApiClientConfig {
+
+    @Bean
+    public WebClient webClient() {
+        HttpClient httpClient = HttpClient.create()
+                                          .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 10000)
+                                          .responseTimeout(Duration.ofSeconds(2));
+
+        return WebClient.builder().clientConnector(new ReactorClientHttpConnector(httpClient))
+                        .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(2 * 1024 * 1024))
+                        .build();
+    }
+}

--- a/srvr-common/src/main/java/kr/kro/srvrstudy/srvr_common/config/WebClientConfig.java
+++ b/srvr-common/src/main/java/kr/kro/srvrstudy/srvr_common/config/WebClientConfig.java
@@ -9,9 +9,8 @@ import reactor.netty.http.client.HttpClient;
 
 import java.time.Duration;
 
-
 @Configuration
-public class ApiClientConfig {
+public class WebClientConfig {
 
     @Bean
     public WebClient webClient() {

--- a/srvr-common/src/main/java/kr/kro/srvrstudy/srvr_common/helper/IdGenerator.java
+++ b/srvr-common/src/main/java/kr/kro/srvrstudy/srvr_common/helper/IdGenerator.java
@@ -1,0 +1,21 @@
+package kr.kro.srvrstudy.srvr_common.helper;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class IdGenerator {
+
+    private static final Long LIMITS_DIGITS = 10_000_000_000_000_000L;
+
+    public static long generate() {
+        long time = (System.currentTimeMillis() + generateUUID().getMostSignificantBits());
+        return time % LIMITS_DIGITS;
+    }
+
+    public static UUID generateUUID() {
+        return UUID.randomUUID();
+    }
+}

--- a/srvr-common/src/main/resources/META-INF/spring.factories
+++ b/srvr-common/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,3 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+kr.kro.srvrstudy.srvr_common.config.WebClientConfig
+

--- a/srvr-common/src/test/java/kr/kro/srvrstudy/srvr_common/helper/IdGeneratorTest.java
+++ b/srvr-common/src/test/java/kr/kro/srvrstudy/srvr_common/helper/IdGeneratorTest.java
@@ -1,0 +1,47 @@
+package kr.kro.srvrstudy.srvr_common.helper;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class IdGeneratorTest {
+
+    @Test
+    @DisplayName("동시 Id 제너레이터 테스트")
+    void generate_500_000_Ids_must_not_be_same_concurrently() {
+        // given
+        int endNumber = 500_000;
+        Map<Long, Object> duplicationCheckMap = new ConcurrentHashMap<>();
+
+        // when
+        IntStream.range(0, endNumber)
+                 .parallel()
+                 .forEach((index) -> duplicationCheckMap.put(IdGenerator.generate(), index));
+
+        // then
+        assertEquals(endNumber, duplicationCheckMap.size());
+    }
+
+    @Test
+    @DisplayName("Id 제너레이터 테스트")
+    void generate_500_000_Ids_must_not_be_same() {
+        // given
+        int endNumber = 500_000;
+        Set<Long> duplicationCheckSet = new HashSet<>();
+
+        // when
+        IntStream.range(0, endNumber)
+                 .forEach((index) -> duplicationCheckSet.add(IdGenerator.generate()));
+
+        // then
+        assertEquals(endNumber, duplicationCheckSet.size());
+    }
+
+}


### PR DESCRIPTION
### 내용 

srvr 프로젝트의 공통으로 사용할 모듈인 srvr_common 모듈을 생성했습니다.

- #10 Api 방식은 불필요한 코드가 많아 지고 실용적이지 않아서 폐기 했습니다. 다른 방법으로 ApiClient를 만들도록 변경하겠습니다.

- 공통 response format 설정
```
responseBody 
{
    header: {
        long code // 에러용
        String message // 에러용
        isSuccessful: true/false,
    },
    content: { GenericType },
    contents: [{ GenericType }],
    totalCount: 0 // contents일 경우에만 노출되는 필드 contents의 개수
}
```

- webClient 설정 추가
기본 설정만 진행했고 추후에 설정을 추가하면 될 듯 합니다.
(아직 설정에 대해서 잘 알지 못 함.)

- IdGenerator 추가, Test 코드 추가
Id 생성 방식을 DB에 의존하지 않고 생성할 수 있도록 만들었습니다. 
이 방식은 성능과 다른 DB에 마이그레이션을 쉽게 진행할 수 있다는 장점이 있습니다.
시간과 UUID 베이스로 17자리 Long 타입의 Id를 생성합니다. 
500,000 개의 Id를 생성 후 겹치는게 있는지 테스트를 진행해보았을 때 겹치지 않았습니다. 


### 주의
- intellij에서 could not autowird 에러가 표시가 나지만 Bean 등록이 되어있기 때문에 실행에 문제없습니다.
- IdGenerator 테스트가 실패하면 알려주시기 바랍니다.