### PR TITLE
feat: main server 스켈레톤 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ out/
 
 ### srvr ###
 coverage
+**/static/docs

--- a/README.md
+++ b/README.md
@@ -10,3 +10,11 @@
 * user, password - root
 * local 개발용으로만 사용
 * feature 서버가 늘어남에 따라 database 늘려야할땐 init 안의 01-databasees.sql에 추가 작성
+
+### 기능 서버들
+
+#### main
+
+srvr의 엔트리 페이지를 담당하는 서버. 각각의 기능 서버의 대한 데이터를 담당하고 있습니다. 
+
+* [ERD](https://www.erdcloud.com/d/htMw4QEQwPe8CpwFW)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+### local Database 세팅 하는 방법
+
+1. docker desktop install
+   * [mac](https://docs.docker.com/desktop/mac/install/)
+   * [window](https://docs.docker.com/desktop/window/install/)
+2. 프로젝트 루트에서 `cd docker`
+3. docker desktop 실행 후 터미널에 `docker-compose up -d` 명령어 실행.
+
+#### 주의사항
+* user, password - root
+* local 개발용으로만 사용
+* feature 서버가 늘어남에 따라 database 늘려야할땐 init 안의 01-databasees.sql에 추가 작성

--- a/build.gradle
+++ b/build.gradle
@@ -1,15 +1,20 @@
 buildscript {
 	ext {
-		springBootVersion = '2.6.1'
+		springBootVersion = '2.6.5'
 	}
 
 	repositories {
 		mavenCentral()
 	}
+
 	dependencies {
 		classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}")
 		classpath "io.spring.gradle:dependency-management-plugin:1.0.11.RELEASE"
 	}
+}
+
+plugins {
+	id "org.asciidoctor.jvm.convert" version "3.3.2"
 }
 
 allprojects {
@@ -21,6 +26,7 @@ subprojects {
 	apply plugin: 'java'
 	apply plugin: 'org.springframework.boot'
 	apply plugin: 'io.spring.dependency-management'
+	apply plugin: 'org.asciidoctor.jvm.convert'
 
 	group = 'kr.kro.srvr-study'
 	version = '0.0.1-SNAPSHOT'
@@ -30,20 +36,52 @@ subprojects {
 		mavenCentral()
 	}
 
+	configurations {
+		asciidoctorExt
+
+		compileOnly {
+			extendsFrom annotationProcessor
+		}
+	}
+
 	dependencies {
 		implementation 'org.springframework.boot:spring-boot-starter'
 		implementation 'org.projectlombok:lombok:1.18.22'
+		asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+		testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 		testImplementation 'org.springframework.boot:spring-boot-starter-test'
 		annotationProcessor 'org.projectlombok:lombok:1.18.22'
+	}
 
-		configurations {
-			compileOnly {
-				extendsFrom annotationProcessor
-			}
-		}
+	ext {
+		set('snippetsDir', file("build/generated-snippets"))
 	}
 
 	test {
 		useJUnitPlatform()
+		outputs.dir snippetsDir
+	}
+
+	asciidoctor {
+		dependsOn test
+		configurations 'asciidoctorExt'
+		inputs.dir snippetsDir
+	}
+
+	task copyDocument(type: Copy) {
+		dependsOn asciidoctor
+		from file(asciidoctor.outputDir)
+		into file("src/main/resources/static/docs")
+	}
+
+	build {
+		dependsOn copyDocument
+	}
+
+	bootJar {
+		dependsOn asciidoctor
+		from ("${asciidoctor.outputDir}") {
+			into "src/main/resources/static/docs"
+		}
 	}
 }

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,16 @@
+version: "3.1"
+services:
+  srvr-local-db:
+    platform: linux/x86_64
+    container_name: srvr-local-db
+    image: mysql:latest
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+    ports:
+      - 3306:3306
+    volumes:
+      - ./init:/docker-entrypoint-initdb.d
+    command:
+      - --character-set-server=utf8
+      - --collation-server=utf8_general_ci

--- a/docker/init/01-databases.sql
+++ b/docker/init/01-databases.sql
@@ -1,0 +1,7 @@
+-- create databases
+CREATE DATABASE IF NOT EXISTS `srvr-main`;
+CREATE DATABASE IF NOT EXISTS `srvr-auth`;
+
+-- create root user and grant rights
+CREATE USER 'root'@'localhost' IDENTIFIED BY 'local';
+GRANT ALL PRIVILEGES ON *.* TO 'root'@'%';

--- a/srvr-main/src/docs/asciidoc/index.adoc
+++ b/srvr-main/src/docs/asciidoc/index.adoc
@@ -1,0 +1,87 @@
+= SRVR Main API Document
+srvrstudy.kro.kr
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 3
+:sectlinks:
+
+[[introduction]]
+== 소개
+
+SRVR Main API RestDoc 입니다.
+
+[[common]]
+== 공통 사항
+
+API에 관계없이 아래 사항을 지켜주셔야 합니다.
+
+=== Domain
+
+|===
+| 환경 | domain
+
+| 개발서버
+| `localhost:8080`
+
+| 개발서버
+| `srvrstudy.kro.kr:8080`
+
+|===
+
+
+=== Header
+
+|===
+| name | 설명
+
+|===
+
+=== 공통 Response Body
+
+|===
+| field | 설명
+
+| `header`
+| 응답 메타 정보 성공유무, 에러 응답용 message, code
+
+| `code`
+| 예외사항 code
+
+| `message`
+| 예외사항 내용 등 응답 메세지
+
+| `isSuccessful`
+| 응답 성공 유무
+
+| `content`
+| 실제 반환될 데이터
+|===
+
+[[hello]]
+== Hello World API
+
+=== Request
+
+CURL:
+
+include::{snippets}/hello-world/curl-request.adoc[]
+
+Request Parameters:
+
+include::{snippets}/hello-world/request-parameters.adoc[]
+
+Request HTTP Example:
+
+include::{snippets}/hello-world/http-request.adoc[]
+
+=== Response
+
+Response Fields:
+
+include::{snippets}/hello-world/response-fields.adoc[]
+
+Response HTTP Example:
+
+include::{snippets}/hello-world/http-response.adoc[]


### PR DESCRIPTION
### 내용 

srvr 프로젝트의 엔트리 서버인 srvr_main 모듈을 생성했습니다.

- 모든 서버에서 공통으로 사용할 Spring rest docs 설정 추가

src/docs/asciidoc/index.adoc 파일을 생성하면 그 다음 부터 build시 resource/static/docs/index.html가 생성됩니다. 
모든 서버는 {server-host}/docs/index.html로 api 문서에 접근할 수 있습니다.

- local 개발용 docker-compose 설정 추가
docker-compose를 사용하는 방법은 README.md에 업데이트 해두었습니다. 
server가 늘어남에 따라 database를 더 늘리고 싶다면 `/docer/init/01-databases.sql`에 추가합니다.

### 주의
- 현재 pr에 올라가있는 커밋이 들어가 있습니다. 머지한 뒤 rebase 할 얘정입니다.
