### PR TITLE
feat: main server client 생성

### DIFF
--- a/clients/srvr-main-client/build.gradle
+++ b/clients/srvr-main-client/build.gradle
@@ -1,0 +1,6 @@
+dependencies {
+    implementation project(':srvr-common')
+    implementation 'org.springframework:spring-webflux'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
+}

--- a/clients/srvr-main-client/src/main/java/kr/kro/srvrstudy/srvr_main_client/api/MainEchoApi.java
+++ b/clients/srvr-main-client/src/main/java/kr/kro/srvrstudy/srvr_main_client/api/MainEchoApi.java
@@ -1,0 +1,35 @@
+package kr.kro.srvrstudy.srvr_main_client.api;
+
+import kr.kro.srvrstudy.srvr_main_client.config.MainServerClientProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class MainEchoApi {
+
+    private final WebClient webClient;
+    private final MainServerClientProperties properties;
+
+    public Map<String, Object> postEcho(String body) {
+        return this.webClient.method(HttpMethod.POST)
+                             .uri(properties.getEcho())
+                             .bodyValue(body)
+                             .retrieve()
+                             .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {})
+                             .block();
+    }
+
+    public Map<String, Object> getEchoPath(String path) {
+        return this.webClient.method(HttpMethod.GET)
+                             .uri(String.format(properties.getEchoPath(), path))
+                             .retrieve()
+                             .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {})
+                             .block();
+    }
+}

--- a/clients/srvr-main-client/src/main/java/kr/kro/srvrstudy/srvr_main_client/config/MainServerClientConfig.java
+++ b/clients/srvr-main-client/src/main/java/kr/kro/srvrstudy/srvr_main_client/config/MainServerClientConfig.java
@@ -1,0 +1,21 @@
+package kr.kro.srvrstudy.srvr_main_client.config;
+
+import kr.kro.srvrstudy.srvr_main_client.api.MainEchoApi;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+@EnableConfigurationProperties(MainServerClientProperties.class)
+@RequiredArgsConstructor
+public class MainServerClientConfig {
+
+    private final MainServerClientProperties properties;
+
+    @Bean
+    public MainEchoApi echoControllerApi(WebClient webClient) {
+        return new MainEchoApi(webClient, properties);
+    }
+}

--- a/clients/srvr-main-client/src/main/java/kr/kro/srvrstudy/srvr_main_client/config/MainServerClientProperties.java
+++ b/clients/srvr-main-client/src/main/java/kr/kro/srvrstudy/srvr_main_client/config/MainServerClientProperties.java
@@ -1,0 +1,19 @@
+package kr.kro.srvrstudy.srvr_main_client.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import javax.validation.constraints.NotNull;
+
+@ConfigurationProperties (prefix = "srvr.server.main")
+@Getter
+@Setter
+public class MainServerClientProperties {
+
+    @NotNull
+    private String echo;
+
+    @NotNull
+    private String echoPath;
+}

--- a/clients/srvr-main-client/src/main/resources/META-INF/spring.factories
+++ b/clients/srvr-main-client/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+kr.kro.srvrstudy.srvr_main_client.config.MainServerClientConfig

--- a/clients/srvr-main-client/src/test/java/kr/kro/srvrstudy/srvr_main_client/api/MainEchoApiTest.java
+++ b/clients/srvr-main-client/src/test/java/kr/kro/srvrstudy/srvr_main_client/api/MainEchoApiTest.java
@@ -1,0 +1,78 @@
+package kr.kro.srvrstudy.srvr_main_client.api;
+
+import kr.kro.srvrstudy.srvr_common.config.WebClientConfig;
+import kr.kro.srvrstudy.srvr_main_client.config.MainServerClientProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.http.HttpMethod;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {WebClientConfig.class})
+@Disabled
+class MainEchoApiTest {
+
+    @SpyBean
+    private WebClient webClient;
+
+    @Mock
+    private MainServerClientProperties properties;
+
+    private MainEchoApi mainEchoApi = new MainEchoApi(webClient, properties);
+
+    @BeforeEach
+    void setup() {
+        when(properties.getEcho()).thenReturn("http://localhost:8080");
+        when(properties.getEchoPath()).thenReturn("http://localhost:8080/%s");
+
+        this.mainEchoApi = new MainEchoApi(webClient, properties);
+    }
+
+    @Test
+    void requestExampleGetApiTest() {
+        // given
+        int end = 100;
+        ConcurrentHashMap<Integer, String> map = new ConcurrentHashMap<>();
+
+        // when
+        IntStream.range(0, end).parallel().forEach(index -> {
+            Map<String, Object> result = mainEchoApi.getEchoPath(String.valueOf(index));
+            map.put(index, (String) ((Map) result.get("result")).get("content"));
+        });
+
+        // then
+        verify(webClient, times(100)).method(HttpMethod.GET);
+        assertEquals(end, map.size());
+    }
+
+    @Test
+    void requestExamplePostApiTest() {
+        // given
+        int end = 100;
+        ConcurrentHashMap<Integer, String> map = new ConcurrentHashMap<>();
+
+        // when
+        IntStream.range(0, end).parallel().forEach(index -> {
+            Map<String, Object> result = this.mainEchoApi.postEcho(String.valueOf(index));
+            map.put(index, (String) ((Map) result.get("result")).get("content"));
+
+        });
+
+        // then
+        verify(webClient, times(100)).method(HttpMethod.POST);
+        assertEquals(end, map.size());
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,4 @@
 rootProject.name = 'srvr'
 include 'srvr-main'
 include 'srvr-common'
+include 'clients:srvr-main-client'

--- a/srvr-main/build.gradle
+++ b/srvr-main/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
-    implementation('org.springframework.boot:spring-boot-starter-web')
-    implementation('org.springframework.boot:spring-boot-starter-websocket')
+    implementation project(":srvr-common")
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
 }

--- a/srvr-main/src/main/java/kr/kro/srvrstudy/srvr_main/controller/EchoController.java
+++ b/srvr-main/src/main/java/kr/kro/srvrstudy/srvr_main/controller/EchoController.java
@@ -1,0 +1,24 @@
+package kr.kro.srvrstudy.srvr_main.controller;
+
+import kr.kro.srvrstudy.srvr_common.api.response.ApiResponse;
+import kr.kro.srvrstudy.srvr_common.api.response.SuccessResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class EchoController {
+
+    @PostMapping("/")
+    public ApiResponse<String> post(@RequestBody String body) {
+        return new SuccessResponse<>(body);
+    }
+
+    @GetMapping("/{path}")
+    public ApiResponse<String> getPath(@PathVariable String path) {
+        return new SuccessResponse<>(path);
+    }
+
+}

--- a/srvr-main/src/main/java/kr/kro/srvrstudy/srvr_main/controller/EchoController.java
+++ b/srvr-main/src/main/java/kr/kro/srvrstudy/srvr_main/controller/EchoController.java
@@ -6,9 +6,11 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequestMapping("/v1/echo")
 public class EchoController {
 
     @PostMapping("/")


### PR DESCRIPTION
### 내용 

main server의 API를 호출하는 srvr_main_client 모듈을 생성했습니다. 

main server의 API를 호출이 필요한 feater server 모듈에서 srvr_main_client 모듈 dependency 추가하여 사용합니다.

- srvr_main_client를 사용하는 서버는 아래 처럼 api url을 properties에 추가해주어야 합니다.
```
application.properties

srvr.server.main.base_url=http://localhost:8080

srvr.server.main.echo=${srvr.server.main.base_url}
srvr.server.main.echo_path=${srvr.server.main.base_url}/%s
...

```
%s는 path variable입니다. 


- main에 테스트용 echo controller 추가


### 주의
- 테스트가 main 서버에 의존하기 때문에 일단은 @Disabled 어노테이션을 붙여주었습니다.
