### PR TITLE
feat: common 모듈에 에러 핸들용 response 추가

### DIFF
--- a/srvr-common/build.gradle
+++ b/srvr-common/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind'
-    implementation 'org.springframework:spring-webflux'
-    implementation 'org.springframework.boot:spring-boot-starter-reactor-netty'
     implementation 'io.netty:netty-all'
+    implementation 'org.springframework:spring-webflux'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-reactor-netty'
 }

--- a/srvr-common/src/main/java/kr/kro/srvrstudy/srvr_common/api/response/FailureResponse.java
+++ b/srvr-common/src/main/java/kr/kro/srvrstudy/srvr_common/api/response/FailureResponse.java
@@ -1,0 +1,20 @@
+package kr.kro.srvrstudy.srvr_common.api.response;
+
+import kr.kro.srvrstudy.srvr_common.exception.ErrorCode;
+
+import java.util.Collection;
+
+public class FailureResponse<T> extends ApiResponse<T> {
+
+    public FailureResponse(ErrorCode errorCode) {
+        super(new BodyHeader(false, errorCode.getMessage(), errorCode.getCode()), null);
+    }
+
+    public FailureResponse(ErrorCode errorCode, T body) {
+        super(new BodyHeader(false, errorCode.getMessage(), errorCode.getCode()), new BodyContent<>(body));
+    }
+
+    public FailureResponse(ErrorCode errorCode, Collection<T> body) {
+        super(new BodyHeader(false, errorCode.getMessage(), errorCode.getCode()), new BodyContent<>(body));
+    }
+}

--- a/srvr-common/src/main/java/kr/kro/srvrstudy/srvr_common/exception/ApiFailureException.java
+++ b/srvr-common/src/main/java/kr/kro/srvrstudy/srvr_common/exception/ApiFailureException.java
@@ -1,0 +1,15 @@
+package kr.kro.srvrstudy.srvr_common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ApiFailureException extends RuntimeException {
+
+    private static final long serialVersionUID = 731492746908245878L;
+
+    private final ErrorCode errorCode;
+
+    public ApiFailureException(ErrorCode errorCode) {
+        this.errorCode = errorCode;
+    }
+}

--- a/srvr-common/src/main/java/kr/kro/srvrstudy/srvr_common/exception/ErrorCode.java
+++ b/srvr-common/src/main/java/kr/kro/srvrstudy/srvr_common/exception/ErrorCode.java
@@ -1,0 +1,17 @@
+package kr.kro.srvrstudy.srvr_common.exception;
+
+import lombok.Getter;
+
+@Getter
+public enum ErrorCode {
+
+    INVALID_REQUEST(-100000, "Invalid request.");
+
+    private final long code;
+    private final String message;
+
+    ErrorCode(long code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+}


### PR DESCRIPTION
### 내용

- 공통으로 사용할 exception 한개와 enum ErrorCode를 생성
- 너무 많은 exception 클래스가 생성되지 않는 방법으로 하기 위해 위와 같은 방법 적용.
- 에러코드는 음수이며, 처음 2자리는 대분류, 가운데 두자리는 중분류, 마지막 두자리는 소분류를 뜻함.